### PR TITLE
Add CTAButton component with tests and snapshots

### DIFF
--- a/__tests__/components/__snapshots__/cta.test.tsx.snap
+++ b/__tests__/components/__snapshots__/cta.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CTAButton should match snapshot 1`] = `
+<div>
+  <button
+    class="px-4 py-2 font-bold rounded-md text-lg bg-off-white text-charcoal-grey-500"
+  >
+    Test
+  </button>
+</div>
+`;

--- a/__tests__/components/cta.test.tsx
+++ b/__tests__/components/cta.test.tsx
@@ -1,0 +1,99 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import CTAButton from '@/components/cta';
+
+describe('CTAButton', () => {
+  it('renders a button', () => {
+    render(<CTAButton>Test</CTAButton>);
+
+    const button = screen.getByRole('button');
+
+    expect(button).toBeInTheDocument();
+  });
+
+  it('should render with children content', () => {
+    render(<CTAButton>Test</CTAButton>);
+
+    const button = screen.getByRole('button');
+
+    expect(button).toHaveTextContent('Test');
+  });
+
+  it('should render with properly style', () => {
+    render(<CTAButton>Test</CTAButton>);
+
+    const button = screen.getByRole('button');
+
+    expect(button).toHaveClass(
+      'px-4 py-2 font-bold rounded-md text-lg bg-off-white text-charcoal-grey-500'
+    );
+
+    expect(button).not.toHaveClass('bg-deep-blue text-off-white');
+  });
+
+  it('should render with properly style when buttonType is primary', () => {
+    render(<CTAButton buttonType='primary'>Test</CTAButton>);
+
+    const button = screen.getByRole('button');
+
+    expect(button).toHaveClass(
+      'px-4 py-2 font-bold rounded-md text-lg bg-deep-blue text-off-white'
+    );
+  });
+
+  it('should render with properly style when buttonType is secondary', () => {
+    render(<CTAButton buttonType='secondary'>Test</CTAButton>);
+
+    const button = screen.getByRole('button');
+
+    expect(button).toHaveClass(
+      'px-4 py-2 font-bold rounded-md text-lg bg-gold text-off-white'
+    );
+  });
+
+  it('should render with custom class', () => {
+    render(<CTAButton className='custom-class'>Test</CTAButton>);
+
+    const button = screen.getByRole('button');
+
+    expect(button).toHaveClass('custom-class');
+  });
+
+  it('should render with custom class when buttonType is primary', () => {
+    render(
+      <CTAButton className='custom-class' buttonType='primary'>
+        Test
+      </CTAButton>
+    );
+
+    const button = screen.getByRole('button');
+
+    expect(button).toHaveClass('bg-deep-blue text-off-white custom-class');
+  });
+
+  it('fluid button should take full width', () => {
+    render(<CTAButton fluid>Test</CTAButton>);
+
+    const button = screen.getByRole('button');
+
+    expect(button).toHaveClass('w-full');
+  });
+
+  it('should run onClick function', () => {
+    const onClick = jest.fn();
+
+    render(<CTAButton onClick={onClick}>Test</CTAButton>);
+
+    const button = screen.getByRole('button');
+
+    button.click();
+
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('should match snapshot', () => {
+    const { container } = render(<CTAButton>Test</CTAButton>);
+
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/__tests__/page.test.tsx
+++ b/__tests__/page.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import Page from '@/app/page';
 

--- a/src/components/cta/index.tsx
+++ b/src/components/cta/index.tsx
@@ -3,29 +3,40 @@ import { tv } from 'tailwind-variants';
 
 type CTAButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   buttonType?: 'primary' | 'secondary';
+  fluid?: boolean;
 };
 
-const button = tv({
+const buttonVariant = tv({
   base: 'px-4 py-2 font-bold rounded-md text-lg',
   variants: {
     buttonType: {
+      default: 'bg-off-white text-charcoal-grey-500',
       primary: 'bg-deep-blue text-off-white',
       secondary: 'bg-gold text-off-white',
     },
+    fluid: {
+      true: 'w-full',
+    },
+  },
+  defaultVariants: {
+    buttonType: 'default',
+    fluid: false,
   },
 });
 
 const CTAButton: React.FC<CTAButtonProps> = ({
   children,
   buttonType,
+  fluid,
   ...props
 }) => {
   return (
     <button
       {...props}
-      className={button({
+      className={buttonVariant({
         class: props.className,
         buttonType,
+        fluid,
       })}
     >
       {children}


### PR DESCRIPTION
This pull request adds the CTAButton component along with its corresponding tests and snapshots. The CTAButton component is a reusable button component that can be styled based on different button types and can also be rendered as a fluid button.